### PR TITLE
fix(fara-cli): refactor logging for action execution in FaraAgent

### DIFF
--- a/src/fara/fara_agent.py
+++ b/src/fara/fara_agent.py
@@ -378,7 +378,8 @@ class FaraAgent:
             all_actions.append(raw_response)
             thoughts, action_dict = self._parse_thoughts_and_action(raw_response)
             action_args = action_dict.get("arguments", {})
-            self.logger.info(f"\nThought #{i+1}: {thoughts}\nAction #{i+1}: executing tool '{action_args["action"]}' with arguments {json.dumps(action_args)}")
+            action = action_args["action"]
+            self.logger.info(f"\nThought #{i+1}: {thoughts}\nAction #{i+1}: executing tool '{action}' with arguments {json.dumps(action_args)}")
 
             (
                 is_stop_action,


### PR DESCRIPTION
This PR fixes an error that is thrown when running (on macos):

```
fara-cli --task "how many pages does wikipedia have" --start_page "https://www.bing.com"
```

Error: 

```
Traceback (most recent call last):
  File "/Users/wassimchegham/anaconda3/envs/fara/bin/fara-cli", line 3, in <module>
    from fara.run_fara import main
  File "/Users/wassimchegham/oss/@microsoft/fara/src/fara/__init__.py", line 1, in <module>
    from .fara_agent import FaraAgent
  File "/Users/wassimchegham/oss/@microsoft/fara/src/fara/fara_agent.py", line 381
    self.logger.info(f"\nThought #{i+1}: {thoughts}\nAction #{i+1}: executing tool '{action_args["action"]}' with arguments {json.dumps(action_args)}")
                                                                                                  ^^^^^^
SyntaxError: f-string: unmatched '['
```