### PR TITLE
Added refresh option by using the F5 key.

### DIFF
--- a/src/fara/_prompts.py
+++ b/src/fara/_prompts.py
@@ -33,6 +33,7 @@ Use a mouse and keyboard to interact with a computer, and take screenshots.
 * If a popup window appears that you want to close, if left_click() on the 'X' or close button doesn't work, try key(keys=['Escape']) to close it.
 * On some search bars, when you type(), you may need to press_enter=False and instead separately call left_click() on the search button to submit the search query. This is especially true of search bars that have auto-suggest popups for e.g. locations
 * For calendar widgets, you usually need to left_click() on arrows to move between months and left_click() on dates to select them; type() is not typically used to input dates there.
+* If asked to monitor a page for changes, you can use wait() to pause for a while and avoid busy-waiting. You may also need to follow that with key() to press F5 so that the page refreshes with the latest content.
 """.strip()
 
     parameters = {
@@ -40,7 +41,7 @@ Use a mouse and keyboard to interact with a computer, and take screenshots.
             "action": {
                 "description": """
 The action to perform. The available actions are:
-* `key`: Performs key down presses on the arguments passed in order, then performs key releases in reverse order. Includes "Enter", "Alt", "Shift", "Tab", "Control", "Backspace", "Delete", "Escape", "ArrowUp", "ArrowDown", "ArrowLeft", "ArrowRight", "PageDown", "PageUp", "Shift", etc.
+* `key`: Performs key down presses on the arguments passed in order, then performs key releases in reverse order. Includes "Enter", "Alt", "Shift", "Tab", "Control", "Backspace", "Delete", "Escape", "ArrowUp", "ArrowDown", "ArrowLeft", "ArrowRight", "PageDown", "PageUp", "Shift", "F5", etc.
 * `type`: Type a string of text on the keyboard.
 * `mouse_move`: Move the cursor to a specified (x, y) pixel coordinate on the screen.
 * `left_click`: Click the left mouse button.

--- a/src/fara/browser/playwright_controller.py
+++ b/src/fara/browser/playwright_controller.py
@@ -556,6 +556,13 @@ class PlaywrightController:
             keys (List[str]): List of keys to press
         """
         await self._ensure_page_ready(page)
+
+        # Special-case F5
+        if len(keys) == 1 and keys[0].lower() == "f5":
+            await page.reload()
+            await page.wait_for_load_state()
+            return
+
         mapped_keys = [CUA_KEY_TO_PLAYWRIGHT_KEY.get(key.lower(), key) for key in keys]
         try:
             for key in mapped_keys:


### PR DESCRIPTION
Agents seem to be better at pressing F5 than recognizing a new `refresh` action. This PR special-cases F5 to allow the agents to reload pages as needed.