### PR TITLE
fix: replace 6 bare excepts with except Exception in webeval

### DIFF
--- a/webeval/src/webeval/benchmarks/om2w/impl/src/methods/webjudge_general_eval.py
+++ b/webeval/src/webeval/benchmarks/om2w/impl/src/methods/webjudge_general_eval.py
@@ -150,7 +150,7 @@ The potentially important snapshots of the webpage in the agent's trajectory and
     try:
         key_points = key_points.split("**Key Points**:")[1]
         key_points = "\n".join(line.lstrip() for line in key_points.splitlines())
-    except:
+    except Exception:
         key_points = key_points.split("Key Points:")[-1]
         key_points = "\n".join(line.lstrip() for line in key_points.splitlines())
     

--- a/webeval/src/webeval/benchmarks/om2w/impl/src/methods/webjudge_online_mind2web.py
+++ b/webeval/src/webeval/benchmarks/om2w/impl/src/methods/webjudge_online_mind2web.py
@@ -128,7 +128,7 @@ The potentially important snapshots of the webpage in the agent's trajectory and
     try:
         key_points = key_points.split("**Key Points**:")[1]
         key_points = "\n".join(line.lstrip() for line in key_points.splitlines())
-    except:
+    except Exception:
         key_points = key_points.split("Key Points:")[-1]
         key_points = "\n".join(line.lstrip() for line in key_points.splitlines())
     

--- a/webeval/src/webeval/benchmarks/om2w/impl/src/utils.py
+++ b/webeval/src/webeval/benchmarks/om2w/impl/src/utils.py
@@ -26,7 +26,7 @@ def extract_predication(response, mode):
                 return 1
             else:
                 return 0
-        except:
+        except Exception:
             return 0
     elif mode == "AgentTrek_eval":
         try:
@@ -34,7 +34,7 @@ def extract_predication(response, mode):
                 return 1
             else:
                 return 0
-        except:
+        except Exception:
             return 0
     elif mode == "WebVoyager_eval":
         if "FAILURE" in response:
@@ -47,7 +47,7 @@ def extract_predication(response, mode):
                 return 1
             else:
                 return 0
-        except:
+        except Exception:
             return 0  
     elif mode == "WebJudge_general_eval":
         try:
@@ -55,7 +55,7 @@ def extract_predication(response, mode):
                 return 1
             else:
                 return 0
-        except:
+        except Exception:
             return 0      
     else:
         raise ValueError(f"Unknown mode: {mode}")


### PR DESCRIPTION
Replace bare `except:` with `except Exception:` in 3 files (6 sites) under `webeval/src/webeval/benchmarks/om2w/`.

**Why:** Bare `except:` catches `BaseException` including `KeyboardInterrupt`/`SystemExit`.

**Files:** `utils.py` (4), `webjudge_general_eval.py` (1), `webjudge_online_mind2web.py` (1)