### PR TITLE
Fix NameError from orphaned TrajectoryDiagnosticsResult reference

### DIFF
--- a/webeval/src/webeval/rubric_agent/data_point.py
+++ b/webeval/src/webeval/rubric_agent/data_point.py
@@ -557,7 +557,6 @@ VerificationResultEvent = Annotated[
         MMRubricResult,
         MMRubricOutcomeResult,
         WebJudgeResult,
-        TrajectoryDiagnosticsResult,
         TaskAgentResult,
         VerificationResult,
     ],


### PR DESCRIPTION
## Summary

- Commit acc1404 (\"Remove TrajectoryDiagnosticsResult class\") deleted the class but left an orphan reference inside the `VerificationResultEvent` discriminated `Union` in `webeval/src/webeval/rubric_agent/data_point.py:560`.
- Import-time `NameError: name 'TrajectoryDiagnosticsResult' is not defined` cascades into every test that transitively imports the rubric agent — 9 failures + 4 errors on a fresh `pytest webeval/tests/` against `main`.
- This PR deletes the single orphan line; `VerificationResultEvent` now only lists types that still exist.

## Test plan

- [x] `pytest webeval/tests/` → **27 passed, 2 skipped** (was 14 passed, 9 failed, 4 errors, 2 skipped before this change).
- [ ] CI green on the PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)