### PR TITLE
docs: WebTailBench V1↔V2 diff page + README refresh note

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,6 +17,13 @@
 
 ## Updates
 
+* **2026-05-12** — Refreshed **WebTailBench (V2)** tasks and rubrics.
+  Many V1 tasks had calendar-bound dates that expired (Nov 2025); V2
+  rolls those forward and revises the precomputed rubrics for the
+  full 609-task suite. Available now as the `test-v2` split on
+  [`microsoft/WebTailBench`](https://huggingface.co/datasets/microsoft/WebTailBench).
+  A side-by-side V1↔V2 diff (task strings and rubric JSON) is
+  hosted [here](https://microsoft.github.io/fara/docs/webtailbench_v1_v2_diff.html).
 * **2026-04-19** — Released **[CUAVerifierBench](https://huggingface.co/datasets/microsoft/CUAVerifierBench)**,
   a human-annotated benchmark for evaluating CUA verifiers (i.e. judges that
   score agent trajectories). Two splits — `fara7b_om2w_browserbase` (106

--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@
 * **2026-05-12** — Refreshed **WebTailBench (V2)** tasks and rubrics.
   Many V1 tasks had calendar-bound dates that expired (Nov 2025); V2
   rolls those forward and revises the precomputed rubrics for the
-  full 609-task suite. Available now as the `test-v2` split on
+  full 609-task suite. Available now as the `test_v2` split on
   [`microsoft/WebTailBench`](https://huggingface.co/datasets/microsoft/WebTailBench).
   A side-by-side V1↔V2 diff (task strings and rubric JSON) is
   hosted [here](https://microsoft.github.io/fara/docs/webtailbench_v1_v2_diff.html).


### PR DESCRIPTION
## Summary

- Adds `docs/webtailbench_v1_v2_diff.html` — a side-by-side viewer comparing the 609 WebTailBench tasks between **V1** (current `test` split, valid through Nov 2025) and **V2** (new `test-v2` split, refreshed May 2026). Each row shows V1 task / V2 task with word-level highlighting, and a collapsible unified diff of the per-task `precomputed_rubric` JSON.
- Adds a `2026-05-12` entry to the README **Updates** section announcing the refresh and linking to the diff page.

Once merged, the diff will live at
https://microsoft.github.io/fara/docs/webtailbench_v1_v2_diff.html
(GH Pages already configured on `main` for this repo).

## Notes

- 270/609 task strings changed; 609/609 rubrics regenerated.
- Default view filters to "task changed" so V1↔V2 wording diffs are visible at a glance; a dropdown switches to rubric-only or both.
- Filter UI is pure HTML/JS (no external assets); the file is ~5.6 MB self-contained.

## Test plan

- [ ] Visit https://microsoft.github.io/fara/docs/webtailbench_v1_v2_diff.html after Pages rebuilds and confirm rendering.
- [ ] Spot-check a few diff rows (badges, rubric expand, segment filter, search).

🤖 Generated with [Claude Code](https://claude.com/claude-code)